### PR TITLE
Fix syntax error

### DIFF
--- a/docdetect/canny_edges.py
+++ b/docdetect/canny_edges.py
@@ -20,7 +20,7 @@ def _preprocess(im, blur_radius):
 
 
 def _find_characters(im, max_area):
-    mser = cv2.MSER_create(_max_area=max_area)
+    mser = cv2.MSER_create(max_area=max_area)
     gray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)
     characters, _ = mser.detectRegions(gray)
     return characters


### PR DESCRIPTION
Fixes the following syntax error preventing images being processed:
```
TypeError: '_max_area' is an invalid keyword argument for MSER_create()
```
Closes #3 